### PR TITLE
Added missing exec_depend on gazebo_ros

### DIFF
--- a/ur_simulation_gazebo/package.xml
+++ b/ur_simulation_gazebo/package.xml
@@ -19,6 +19,7 @@
 
   <depend>rclpy</depend>
 
+  <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>launch</exec_depend>


### PR DESCRIPTION
As this is required by the launch file