### PR TITLE
remove c++ linters as this repo doesn't contain any c++ code

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          linter: [cppcheck, copyright, lint_cmake]
+          linter: [copyright, lint_cmake]
     steps:
     - uses: actions/checkout@v1
     - uses: ros-tooling/setup-ros@v0.2
@@ -17,24 +17,5 @@ jobs:
       with:
         distribution: rolling
         linter: ${{ matrix.linter }}
-        package-name:
-          ur_simulation_gazebo
-
-
-  ament_lint_100:
-    name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-          linter: [cpplint]
-    steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@v0.2
-    - uses: ros-tooling/action-ros-lint@v0.1
-      with:
-        distribution: rolling
-        linter: cpplint
-        arguments: "--linelength=100 --filter=-whitespace/newline"
         package-name:
           ur_simulation_gazebo


### PR DESCRIPTION
I was a bit confused about the failing CI pipelines in #1. This PR currently only fixes the c++-linter-related ones.