### PR TITLE
Provide an own set of controllers.yaml file to reduce dependencies

### DIFF
--- a/Universal_Robots_ROS2_Gazebo_Simulation-not-released.galactic.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation-not-released.galactic.repos
@@ -1,10 +1,9 @@
 repositories:
+
   gazebo_ros2_control:
     type: git
-    url: https://github.com/destogl/gazebo_ros2_control.git
-    version: add-support-for-initial-position
-    #url: https://github.com/ros-simulation/gazebo_ros2_control.git
-    #version: master
+    url: https://github.com/ros-simulation/gazebo_ros2_control.git
+    version: master
 
   ros2_control_demos:
     type: git

--- a/Universal_Robots_ROS2_Gazebo_Simulation-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation-not-released.rolling.repos
@@ -1,10 +1,9 @@
 repositories:
+
   gazebo_ros2_control:
     type: git
-    url: https://github.com/destogl/gazebo_ros2_control.git
-    version: add-support-for-initial-position
-    #url: https://github.com/ros-simulation/gazebo_ros2_control.git
-    #version: master
+    url: https://github.com/ros-simulation/gazebo_ros2_control.git
+    version: master
 
   ros2_control_demos:
     type: git

--- a/Universal_Robots_ROS2_Gazebo_Simulation.galactic.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation.galactic.repos
@@ -32,7 +32,7 @@ repositories:
   Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: simulation
+    version: ros2
   Universal_Robots_ROS2_Driver:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git

--- a/Universal_Robots_ROS2_Gazebo_Simulation.galactic.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation.galactic.repos
@@ -1,10 +1,9 @@
 repositories:
+
   gazebo_ros2_control:
     type: git
-    url: https://github.com/destogl/gazebo_ros2_control.git
-    version: add-support-for-initial-position
-    #url: https://github.com/ros-simulation/gazebo_ros2_control.git
-    #version: master
+    url: https://github.com/ros-simulation/gazebo_ros2_control.git
+    version: master
 
   moveit2:
     type: git

--- a/Universal_Robots_ROS2_Gazebo_Simulation.rolling.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation.rolling.repos
@@ -32,7 +32,7 @@ repositories:
   Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: simulation
+    version: ros2
   Universal_Robots_ROS2_Driver:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git

--- a/Universal_Robots_ROS2_Gazebo_Simulation.rolling.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation.rolling.repos
@@ -1,10 +1,9 @@
 repositories:
+
   gazebo_ros2_control:
     type: git
-    url: https://github.com/destogl/gazebo_ros2_control.git
-    version: add-support-for-initial-position
-    #url: https://github.com/ros-simulation/gazebo_ros2_control.git
-    #version: master
+    url: https://github.com/ros-simulation/gazebo_ros2_control.git
+    version: master
 
   moveit2:
     type: git

--- a/ur_simulation_gazebo/CMakeLists.txt
+++ b/ur_simulation_gazebo/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 project(ur_simulation_gazebo)
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_python REQUIRED)
-find_package(rclpy REQUIRED)
 
 install(DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME}

--- a/ur_simulation_gazebo/CMakeLists.txt
+++ b/ur_simulation_gazebo/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(rclpy REQUIRED)
 
-install(DIRECTORY launch
+install(DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/ur_simulation_gazebo/config/ur_controllers.yaml
+++ b/ur_simulation_gazebo/config/ur_controllers.yaml
@@ -1,0 +1,124 @@
+controller_manager:
+  ros__parameters:
+
+    update_rate: 100 # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    io_and_status_controller:
+      type: ur_controllers/GPIOController
+
+    speed_scaling_state_broadcaster:
+      type: ur_controllers/SpeedScalingStateBroadcaster
+
+    force_torque_sensor_broadcaster:
+      type: ur_controllers/ForceTorqueStateBroadcaster
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    scaled_joint_trajectory_controller:
+      type: ur_controllers/ScaledJointTrajectoryController
+
+    forward_velocity_controller:
+      type: velocity_controllers/JointGroupVelocityController
+
+    forward_position_controller:
+      type: position_controllers/JointGroupPositionController
+
+
+speed_scaling_state_broadcaster:
+  ros__parameters:
+    state_publish_rate: 100.0
+
+
+force_torque_sensor_broadcaster:
+  ros__parameters:
+    sensor_name: tcp_fts_sensor
+    state_interface_names:
+      - force.x
+      - force.y
+      - force.z
+      - torque.x
+      - torque.y
+      - torque.z
+    frame_id: tool0
+    topic_name: ft_data
+
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.2
+      goal_time: 0.0
+      shoulder_pan_joint: { trajectory: 0.2, goal: 0.1 }
+      shoulder_lift_joint: { trajectory: 0.2, goal: 0.1 }
+      elbow_joint: { trajectory: 0.2, goal: 0.1 }
+      wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
+      wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
+      wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
+
+
+scaled_joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.2
+      goal_time: 0.0
+      shoulder_pan_joint: { trajectory: 0.2, goal: 0.1 }
+      shoulder_lift_joint: { trajectory: 0.2, goal: 0.1 }
+      elbow_joint: { trajectory: 0.2, goal: 0.1 }
+      wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
+      wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
+      wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
+
+forward_velocity_controller:
+  ros__parameters:
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
+    interface_name: velocity
+
+forward_position_controller:
+  ros__parameters:
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint

--- a/ur_simulation_gazebo/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gazebo/launch/ur_sim_control.launch.py
@@ -236,7 +236,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "runtime_config_package",
-            default_value="ur_bringup",
+            default_value="ur_simulation_gazebo",
             description='Package with the controller\'s configuration in "config" folder. \
         Usually the argument is not set, it enables use of a custom setup.',
         )

--- a/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
@@ -67,7 +67,7 @@ def launch_setup(context, *args, **kwargs):
 
     ur_moveit_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [FindPackageShare("ur_bringup"), "/launch", "/ur_moveit.launch.py"]
+            [FindPackageShare("ur_moveit_config"), "/launch", "/ur_moveit.launch.py"]
         ),
         launch_arguments={
             "ur_type": ur_type,
@@ -112,7 +112,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "runtime_config_package",
-            default_value="ur_bringup",
+            default_value="ur_simulation_gazebo",
             description='Package with the controller\'s configuration in "config" folder. \
         Usually the argument is not set, it enables use of a custom setup.',
         )

--- a/ur_simulation_gazebo/package.xml
+++ b/ur_simulation_gazebo/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur_moveit_config</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/ur_simulation_gazebo/package.xml
+++ b/ur_simulation_gazebo/package.xml
@@ -15,9 +15,6 @@
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Gazebo_Simulation</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_python</buildtool_depend>
-
-  <depend>rclpy</depend>
 
   <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>


### PR DESCRIPTION
Currently, this repo depends on the driver's repository (the `ur_bringup` package) merely because of the `ur_controllers.yaml` file and the `ur_moveit.launch.py` files being included / loaded in this package's launchfiles. Do we want to keep it that way?

As also risen in https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/5#discussion_r792606985 I think, keeping the packages as less depending on each other as possible is desireble.

This would also reduce problems of keeping individual repositories in sync with each other, as for example the one fixed in 76df17236438ff83b1e2d26acf14a2526a40f7be (Sorry for missing a PR there).

Providing an own `ur_controllers.yaml` is pretty simple and doesn't seem like a bad idea to me, but the moveit launchfile is rather hard to factor out. However I'd like to raise the question whether we might want to remove this from this repo completely, as I see this repo more like a component provider for a larger application (a simulated hardware device), while the moveit startup is more part of the application itself. Any (counter?)-opinions on this?