### PR TITLE
Ci setup

### DIFF
--- a/.github/workflows/galactic-binary-build.yml
+++ b/.github/workflows/galactic-binary-build.yml
@@ -15,6 +15,7 @@ jobs:
     name: galactic binary build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env:
           - {ROS_DISTRO: galactic, ROS_REPO: main}

--- a/.github/workflows/galactic-semi-binary-build.yml
+++ b/.github/workflows/galactic-semi-binary-build.yml
@@ -15,6 +15,7 @@ jobs:
     name: galactic semi-binary build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env:
           - {ROS_DISTRO: galactic, ROS_REPO: main}

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -15,6 +15,7 @@ jobs:
     name: rolling binary build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env:
           - {ROS_DISTRO: rolling, ROS_REPO: main}

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -15,6 +15,7 @@ jobs:
     name: rolling semi-binary build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env:
           - {ROS_DISTRO: rolling, ROS_REPO: main}

--- a/Universal_Robots_ROS2_Gazebo_Simulation-not-released.galactic.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation-not-released.galactic.repos
@@ -1,15 +1,4 @@
 repositories:
-
-  gazebo_ros2_control:
-    type: git
-    url: https://github.com/ros-simulation/gazebo_ros2_control.git
-    version: master
-
-  ros2_control_demos:
-    type: git
-    url: https://github.com/ros-controls/ros2_control_demos.git
-    version: master
-
   Universal_Robots_Client_Library:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git

--- a/Universal_Robots_ROS2_Gazebo_Simulation.galactic.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation.galactic.repos
@@ -3,7 +3,7 @@ repositories:
   gazebo_ros2_control:
     type: git
     url: https://github.com/ros-simulation/gazebo_ros2_control.git
-    version: master
+    version: galactic
 
   moveit2:
     type: git


### PR DESCRIPTION
This PR aims at improving the CI situation for this repo. Currently most builds are failing, but it is not necessarily obvious why and what is failing.

Therefore, I suggest to disable failing fast in binary and semi-binary builds, as there might be situations where the testing packages are fine, but the released ones are not or the other way around. When fail-fast ist enabled, the other job will get aborted before we see the result.