### PR TITLE
pass use_fake_hardware to moveit to change default controller

### DIFF
--- a/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
@@ -79,6 +79,7 @@ def launch_setup(context, *args, **kwargs):
             "prefix": prefix,
             "use_sim_time": "true",
             "launch_rviz": "true",
+            "use_fake_hardware" : "true" # to change moveit default controller to joint_trajectory_controller
         }.items(),
     )
 


### PR DESCRIPTION
Fixes https://github.com/UniversalRobots/Universal_Robots_ROS2_Gazebo_Simulation/issues/21