### PR TITLE
Pass use_mock_hardware to moveit launchfile

### DIFF
--- a/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
@@ -79,6 +79,7 @@ def launch_setup(context, *args, **kwargs):
             "prefix": prefix,
             "use_sim_time": "true",
             "launch_rviz": "true",
+            "use_mock_hardware": "true",
         }.items(),
     )
 


### PR DESCRIPTION
Fixes #21. #8. Replaces #22, since for rolling this was renamed to `use_mock_hardware`.