### PR TITLE
Swap control and moveit launchfiles

### DIFF
--- a/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gazebo/launch/ur_sim_moveit.launch.py
@@ -83,8 +83,8 @@ def launch_setup(context, *args, **kwargs):
     )
 
     nodes_to_launch = [
-        ur_control_launch,
         ur_moveit_launch,
+        ur_control_launch,
     ]
 
     return nodes_to_launch


### PR DESCRIPTION
This seems to prevent RViz from being spawned twice. Aims at resolving #17 