### PR TITLE
Add scheduled builds to iron branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+  - name: Backport to humble branch
+    conditions:
+      - base=iron
+      - label=backport-humble
+    actions:
+      backport:
+        branches:
+          - humble
+        labels:
+          - humble

--- a/.github/workflows/humble-binary-main.yml
+++ b/.github/workflows/humble-binary-main.yml
@@ -1,0 +1,21 @@
+name: Humble Binary Main
+on:
+  workflow_dispatch:
+    branches:
+      - humble
+  pull_request:
+    branches:
+      - humble
+  push:
+    branches:
+      - humble
+  schedule:
+    - cron: '13 4 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: humble
+      ros_repo: main
+      ref_for_scheduled_build: humble

--- a/.github/workflows/humble-binary-testing.yml
+++ b/.github/workflows/humble-binary-testing.yml
@@ -1,0 +1,21 @@
+name: Humble Binary Testing
+on:
+  workflow_dispatch:
+    branches:
+      - humble
+  pull_request:
+    branches:
+      - humble
+  push:
+    branches:
+      - humble
+  schedule:
+    - cron: '13 4 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      ref_for_scheduled_build: humble

--- a/.github/workflows/humble-semi-binary-main.yml
+++ b/.github/workflows/humble-semi-binary-main.yml
@@ -1,0 +1,22 @@
+name: Humble Semi Binary Main
+on:
+  workflow_dispatch:
+    branches:
+      - humble
+  pull_request:
+    branches:
+      - humble
+  push:
+    branches:
+      - humble
+  schedule:
+    - cron: '13 4 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: humble
+      ros_repo: main
+      ref_for_scheduled_build: humble
+      upstream_workspace: Universal_Robots_ROS2_Gazebo_Simulation.humble.repos

--- a/.github/workflows/humble-semi-binary-testing.yml
+++ b/.github/workflows/humble-semi-binary-testing.yml
@@ -1,0 +1,22 @@
+name: Humble Semi Binary Testing
+on:
+  workflow_dispatch:
+    branches:
+      - humble
+  pull_request:
+    branches:
+      - humble
+  push:
+    branches:
+      - humble
+  schedule:
+    - cron: '13 4 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      ref_for_scheduled_build: humble
+      upstream_workspace: Universal_Robots_ROS2_Gazebo_Simulation.humble.repos

--- a/Universal_Robots_ROS2_Gazebo_Simulation.humble.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation.humble.repos
@@ -1,0 +1,30 @@
+repositories:
+  ur_description:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description
+    version: humble
+
+  gazebo_ros2_control:
+    type: git
+    url: https://github.com/ros-simulation/gazebo_ros2_control.git
+    version: humble
+
+  moveit2:
+    type: git
+    url: https://github.com/ros-planning/moveit2.git
+    version: humble
+
+  moveit_msgs:
+    type: git
+    url: https://github.com/ros-planning/moveit_msgs.git
+    version: humble
+
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: humble
+
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers.git
+    version: humble

--- a/Universal_Robots_ROS2_Gazebo_Simulation.iron.repos
+++ b/Universal_Robots_ROS2_Gazebo_Simulation.iron.repos
@@ -1,4 +1,8 @@
 repositories:
+  ur_description:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description
+    version: iron
 
   gazebo_ros2_control:
     type: git


### PR DESCRIPTION
Since the iron branch is now the default branch, we need to run scheduled builds off that.