### PR TITLE
Add an if-condition to RViz delay

### DIFF
--- a/ur_simulation_gazebo/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gazebo/launch/ur_sim_control.launch.py
@@ -130,7 +130,8 @@ def launch_setup(context, *args, **kwargs):
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[rviz_node],
-        )
+        ),
+        condition=IfCondition(launch_rviz),
     )
 
     # There may be other controllers of the joints, but this is the initially-started one


### PR DESCRIPTION
This prevents RViz from spawning twice if the moveit startup is used.

Closes #17 