### PR TITLE
Run ci-ros-lint on a ubuntu-latest runner

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -6,16 +6,20 @@ jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
     strategy:
       fail-fast: false
       matrix:
           linter: [copyright, lint_cmake]
     steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@v0.2
+    - uses: actions/checkout@v4
+    - uses: ros-tooling/setup-ros@v0.7
+      with:
+        required-ros-distributions: humble
     - uses: ros-tooling/action-ros-lint@v0.1
       with:
-        distribution: rolling
+        distribution: humble
         linter: ${{ matrix.linter }}
         package-name:
           ur_simulation_gazebo


### PR DESCRIPTION
No reason to run it on a specific version and 20.04 will run out of support.