### PR TITLE
Install ros2pkg in CI

### DIFF
--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -77,6 +77,7 @@ jobs:
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
+          ADDITIONAL_DEBS: ros-${{ inputs.ros_distro }}-ros2pkg # gazebo_ros doesn't expose this, though it's a runtime requirement
       - name: prepare target_ws for cache
         if: ${{ always() && ! matrix.env.CCOV }}
         run: |


### PR DESCRIPTION
In our CI container we don't install any ros-core package, but only the declared dependencies. Upstream gazebo_ros fails to export its ros2pkg dependency and therefore, that's missing when running the tests.